### PR TITLE
feat(seo): Add keywords for improved search visibility

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,7 @@ description: >-
   SoloScripted: Crafting innovative AI-powered games for mobile and web.
   Explore unique gaming experiences.
 url: "https://soloscripted.com"
+keywords: "AI game development, solo game developer, indie games, mobile games, web games, Sudokode, AI-powered games, game development, innovative games"
 baseurl: ""
 
 github_username: soloscripted

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ page.title | default: site.title }}</title>
     <meta name="description" content="{{ page.description | default: site.description | escape }}">
+    <meta name="keywords" content="{{ page.keywords | default: site.keywords | escape }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}" />
     <meta property="og:title" content="{{ page.og_title | default: page.title | default: site.title }}">
     <meta property="og:description"

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@ og_title: "SoloScripted - AI-Powered Mobile & Web Game Development"
 og_description: "Crafting innovative, AI-powered mobile & web games as a solo venture. Explore the future of digital entertainment."
 twitter_title: "SoloScripted - AI-Powered Mobile & Web Game Development"
 twitter_description: "Crafting innovative, AI-powered mobile & web games as a solo venture. Explore the future of digital entertainment."
+keywords: "SoloScripted, AI game development, solo game developer, indie games, mobile games, web games, AI-powered games, game development studio, innovative games, interactive entertainment"
 ---
 
 <section id="hero" class="py-20 text-center min-h-screen max-w-7xl mx-auto">

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Privacy Policy - SoloScripted
+keywords: "SoloScripted, Privacy Policy, data protection, GDPR, user data, advertising, cookies"
 ---
 <section class="py-20">
     <div class="container mx-auto px-4 max-w-4xl">

--- a/docs/sudokode.html
+++ b/docs/sudokode.html
@@ -8,6 +8,7 @@ og_image: /img/sudokode.png
 twitter_title: Sudokode - The AI-Enhanced Sudoku Experience
 twitter_description: Challenge yourself with Sudokode, a modern Sudoku game featuring AI-generated puzzles and intelligent hints. Play the alpha version now!
 twitter_image: /img/sudokode.png
+keywords: "Sudokode, Sudoku, AI Sudoku, free Sudoku, web Sudoku, online Sudoku, puzzle game, AI-powered game, smart hints, puzzle generation, SoloScripted"
 ---
 
 <!-- Hero Section -->

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Terms of Service - SoloScripted
+keywords: "SoloScripted, Terms of Service, legal, user agreement, game policies"
 ---
 <section class="py-20">
     <div class="container mx-auto px-4 max-w-4xl">


### PR DESCRIPTION
This commit introduces the `keywords` meta tag to enhance the site's on-page SEO and improve its discoverability by search engines.

- The default layout is updated to include a dynamic `meta name="keywords"` tag. This tag pulls content from the `keywords` variable in a page's front matter, providing page-specific SEO.

- Relevant, targeted keywords have been added to the front matter of key pages:
  - `index.html`
  - `sudokode.html`
  - `privacy.html`
  - `terms.html`