### PR TITLE
feat: Activate Google Play button and add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+# Makefile for managing the Jekyll site located in the /docs directory.
+
+# Variables
+JEKYLL_CMD = bundle exec jekyll
+SOURCE_DIR = docs
+
+.PHONY: all build serve clean doctor install help
+
+all: help
+
+# Installs the required Ruby gems using Bundler.
+install:
+	@echo "--> Installing dependencies from Gemfile..."
+	cd $(SOURCE_DIR) && bundle install
+
+# Builds the Jekyll site from the docs/ directory.
+build:
+	@echo "--> Building Jekyll site..."
+	cd $(SOURCE_DIR) && $(JEKYLL_CMD) build
+
+# Serves the site locally with live-reloading.
+# Access it at http://localhost:4000
+serve:
+	@echo "--> Starting Jekyll server at http://localhost:4000"
+	@echo "    Press Ctrl+C to stop."
+	cd $(SOURCE_DIR) && $(JEKYLL_CMD) serve --livereload
+
+# Removes the generated site and Jekyll metadata.
+clean:
+	@echo "--> Cleaning the site..."
+	cd $(SOURCE_DIR) && $(JEKYLL_CMD) clean
+
+# Checks the site for any configuration problems.
+doctor:
+	@echo "--> Checking for site configuration issues..."
+	cd $(SOURCE_DIR) && $(JEKYLL_CMD) doctor
+
+# Displays this help message.
+help:
+	@echo "Available targets:"
+	@echo "  install - Install dependencies"
+	@echo "  build   - Build the site"
+	@echo "  serve   - Serve the site locally with live-reload"
+	@echo "  clean   - Remove generated files"
+	@echo "  doctor  - Check for site configuration issues"
+	@echo "  help    - Show this help message"

--- a/docs/sudokode.html
+++ b/docs/sudokode.html
@@ -46,11 +46,11 @@ keywords: "Sudokode, Sudoku, AI Sudoku, free Sudoku, web Sudoku, online Sudoku, 
                 class="bg-green-600 hover:bg-green-700 text-white font-bold py-3 px-6 rounded-lg text-lg transition duration-300">
                 <i class="fas fa-play mr-2"></i>Play on Web
             </a>
-            <!-- Google Play (Coming Soon) -->
-            <div class="bg-gray-700 text-gray-400 font-bold py-3 px-6 rounded-lg text-lg opacity-60 cursor-not-allowed flex items-center" title="Coming Soon to the Google Play Store">
+            <!-- Google Play -->
+            <a href="https://play.google.com/store/apps/details?id=com.soloscripted.sudokodeq" target="_blank" rel="noopener noreferrer" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-lg text-lg transition duration-300 flex items-center" title="Get Sudokode on the Google Play Store">
                 <i class="fab fa-google-play mr-2"></i>
-                <span>Google Play (Soon)</span>
-            </div>
+                <span>Test it on Android</span>
+            </a>
             <!-- App Store (Coming Soon) -->
             <div class="bg-gray-700 text-gray-400 font-bold py-3 px-6 rounded-lg text-lg opacity-60 cursor-not-allowed flex items-center" title="Coming Soon to the Apple App Store">
                 <i class="fab fa-apple mr-2"></i>


### PR DESCRIPTION
This commit introduces two main improvements: activating the Google Play download button on the Sudokode page and adding a Makefile to streamline the development workflow.

Key changes:

- **sudokode.html**: The disabled "Google Play (Soon)" button has been converted into a functional link pointing to the alpha release on the Google Play Store. The styling was updated to an active state to improve user experience.

- **Makefile**: A new `Makefile` is added to the project root. It includes common Jekyll targets (`serve`, `build`, `clean`, `install`, etc.) to simplify local development and site management.